### PR TITLE
Link Xresource

### DIFF
--- a/gui/gx_melmatcheq_x11ui.c
+++ b/gui/gx_melmatcheq_x11ui.c
@@ -18,9 +18,8 @@
 #include <X11/Xutil.h>
 #include <X11/keysym.h>
 #include <X11/Xatom.h>
-#include <X11/Xlib.h>
 #include <X11/Xresource.h>
-#include <X11/Xutil.h>
+
 
 #include "./gx_melmatcheq.h"
 

--- a/gui/gx_melmatcheq_x11ui.c
+++ b/gui/gx_melmatcheq_x11ui.c
@@ -18,6 +18,9 @@
 #include <X11/Xutil.h>
 #include <X11/keysym.h>
 #include <X11/Xatom.h>
+#include <X11/Xlib.h>
+#include <X11/Xresource.h>
+#include <X11/Xutil.h>
 
 #include "./gx_melmatcheq.h"
 


### PR DESCRIPTION
When compiling according to this git master, I get:

```
In file included from gui/gx_melmatcheq_x11ui.c:18:
gui/gx_melmatcheq_x11ui.c: In function ‘instantiate’:
gui/gx_melmatcheq_x11ui.c:360:27: error: implicit declaration of function ‘XrmUniqueQuark’ [-Wimplicit-function-declaration]
  360 |     ui->widgets_context = XUniqueContext();
      |                           ^~~~~~~~~~~~~~
make: *** [Makefile:114: gx_melmatcheq] Error 1
```

This can be fixed by doing the following:

```
mothwoman@mothwoman-msi:~/Desktop/MelMatchEQ.lv2$ git diff
diff --git a/gui/gx_melmatcheq_x11ui.c b/gui/gx_melmatcheq_x11ui.c
index 7fb67c5..c409c47 100644
--- a/gui/gx_melmatcheq_x11ui.c
+++ b/gui/gx_melmatcheq_x11ui.c
@@ -18,6 +18,7 @@
 #include <X11/Xutil.h>
 #include <X11/keysym.h>
 #include <X11/Xatom.h>
+#include <X11/Xresource.h>
 
 #include "./gx_melmatcheq.h"
```
